### PR TITLE
please, add this to enable seamonkey support

### DIFF
--- a/chrome.manifest
+++ b/chrome.manifest
@@ -11,3 +11,4 @@ locale    bartab   ru            locale/ru/
 locale    bartab   es-ES         locale/es-ES/
 
 overlay   chrome://browser/content/browser.xul chrome://bartab/content/browser.xul
+overlay   chrome://navigator/content/navigator.xul chrome://bartab/content/browser.xul

--- a/chrome.manifest.rel
+++ b/chrome.manifest.rel
@@ -11,3 +11,4 @@ locale    bartab   ru            jar:bartab.jar!/locale/ru/
 locale    bartab   es-ES         jar:bartab.jar!/locale/es-ES/
 
 overlay   chrome://browser/content/browser.xul chrome://bartab/content/browser.xul
+overlay   chrome://navigator/content/navigator.xul chrome://bartab/content/browser.xul

--- a/install.rdf
+++ b/install.rdf
@@ -17,11 +17,20 @@
     <em:translator>Felipe Barousse Boué [es]</em:translator>
     <em:translator>Danny Navarro [es-ES]</em:translator>
     <em:optionsURL>chrome://bartab/content/preferences.xul</em:optionsURL>
+    <!-- Firefox -->
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id> <!-- Firefox -->
         <em:minVersion>3.5</em:minVersion>
         <em:maxVersion>4.0b3</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+    <!-- SeaMonkey -->
+    <em:targetApplication>
+      <Description>
+        <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
+        <em:minVersion>2.0.8</em:minVersion>
+        <em:maxVersion>2.1b1</em:maxVersion>
       </Description>
     </em:targetApplication>
   </Description>


### PR DESCRIPTION
I check this changes with seamonkey stable (2.0.8) and nightly trunk. 
It seems work as firefox - tab mouse menu, options dialog, and tab loading delay.
