### PR TITLE
When the last child tab is unloaded, the tab was wrongly detached from the tree. (with Tree Style Tab)

### DIFF
--- a/modules/prototypes.js
+++ b/modules/prototypes.js
@@ -267,6 +267,11 @@ BarTabHandler.prototype = {
 
         // Restore tree when using Tree Style Tab
         if (tabbrowser.treeStyleTab) {
+            let parent = tabbrowser.treeStyleTab.getParentTab(aTab);
+            if (parent) {
+                tabbrowser.treeStyleTab.attachTabTo(newtab, parent,
+                    {dontAnimate: true, insertBefore: aTab.nextSibling});
+            }
             let children = tabbrowser.treeStyleTab.getChildTabs(aTab);
             children.forEach(function(aChild) {
                 tabbrowser.treeStyleTab.attachTabTo(


### PR DESCRIPTION
When Tree Style Tab is installed and there is a tree like following, "1.1" and "1.2" can be unloaded correctly but "1.3" can't.
- 1
  - 1.1
  - 1.2
  - 1.3

If I unload the tab "1.3", then the tab unexpectedly detached from the tree.

To solve this problem, I added some codes to your BarTab to attach the newly opened tab to the original parent manually via TST's API.
